### PR TITLE
Add pagination to query

### DIFF
--- a/lib/payrix/resource.ex
+++ b/lib/payrix/resource.ex
@@ -21,6 +21,7 @@ defmodule Payrix.Resource do
           request(:get, "/#{@resource}")
           |> apply_search(options)
           |> apply_expand(options)
+          |> apply_pagination(options)
           |> authorize_request(options)
           |> send_json_request
           |> Payrix.Resource.parse_response()


### PR DESCRIPTION
Currently, pagination options are only applied in `Payrix.Stream#fetch_next_page`, which is called by `Payrix.Stream#from_request` inside of `Payrix.Resource#stream_query`. Here they are utilized so that the stream function can start at the beginning of a request and paginate to the very end.

This PR simply adds them to `Payrix.Resource#query` so that a plain query can also specify a page number and the amount of records per page.